### PR TITLE
internal_sccの実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 Thumbs.db
+__pycache__

--- a/atcoder/__init__.py
+++ b/atcoder/__init__.py
@@ -9,9 +9,10 @@ from atcoder.internal_csr import Csr
 from atcoder.mincostflow import MinCostFlow
 from atcoder.segtree import SegTree
 from atcoder.internal_scc import InternalScc
+from atcoder.scc import Scc
 
 __all__ = [
     'Sample', 'ceil_pow2', 'bsf', 'LazySegTree', 'is_prime', 'inv_gcd',
     'primitive_root', 'Convolution', 'MaxFlow', 'inv_mod', 'crt', 'floor_sum',
-    'Csr', 'MinCostFlow', 'SegTree', 'InternalScc'
+    'Csr', 'MinCostFlow', 'SegTree', 'InternalScc', 'Scc'
 ]

--- a/atcoder/__init__.py
+++ b/atcoder/__init__.py
@@ -8,9 +8,10 @@ from atcoder.math_acl import inv_mod, crt, floor_sum
 from atcoder.internal_csr import Csr
 from atcoder.mincostflow import MinCostFlow
 from atcoder.segtree import SegTree
+from atcoder.internal_scc import InternalScc
 
 __all__ = [
     'Sample', 'ceil_pow2', 'bsf', 'LazySegTree', 'is_prime', 'inv_gcd',
     'primitive_root', 'Convolution', 'MaxFlow', 'inv_mod', 'crt', 'floor_sum',
-    'Csr', 'MinCostFlow', 'SegTree'
+    'Csr', 'MinCostFlow', 'SegTree', 'InternalScc'
 ]

--- a/atcoder/internal_scc.py
+++ b/atcoder/internal_scc.py
@@ -1,10 +1,117 @@
+from atcoder import Csr
+import sys
+
+
 class InternalScc():
+    """
+    有向グラフの強連結成分分解
+    https://atcoder.github.io/ac-library/document_ja/scc.html
+
+    Parameters
+    ----------
+    n : int
+        グラフの頂点数
+
+    Attributes
+    ----------
+    _n : int
+        グラフの頂点数
+    _edges : list[(from_, to))]
+        from_, toは全てint型
+        辺の始点がfrom_
+        辺の終点がto
+
+    Methods
+    -------
+    __init__(self, n=0)
+        初期化
+    num_verticles(self)
+        頂点数を返却する。
+        Returns
+        ----------
+        _n : int
+    add_edge(self, from_, to)
+        グラフに始点from_,終点toの有向辺を追加する。
+        Parameters
+        ----------
+        from_ : int
+            0 <= from_ < self._n
+        to : int
+            0 <= to < self._n
+    scc_ids(self)
+        強連結成分分解を行う関数。
+        Returns
+        ----------
+        [group_num, ids] : list
+            group_num : int
+                グループ(強連結成分)の個数
+            ids : list
+                各頂点のグループid
+    scc(self)
+        以下の条件を満たすような、「強連結成分となっている頂点のリスト」のリストを返却する。
+        ※トポロジカルソート済
+        Returns
+        ----------
+        groups : list
+            強連結成分の行数をKとすると、下記の形式となる。
+            [頂点(int)のリスト for _ in range(K)]
+    """
+
     def __init__(self, n=0):
         self._n = n
-        self.edges = [] # [int, edge]
-        
+        self._edges = []  # (int, edge)
+
     def num_vertices(self):
         return self._n
-    
+
     def add_edge(self, from_, to):
-        self.edges.append([from_, [to]])
+        self._edges.append((from_, to))
+
+    def scc_ids(self):
+        g = Csr(self._n, self._edges)
+        now_ord, group_num = 0, 0
+        visited = []
+        low = [0] * self._n
+        ids = [0] * self._n
+        ord_ = [-1] * self._n
+
+        # 再帰関数の上限を変更
+        sys.setrecursionlimit(max(self._n + 1000, sys.getrecursionlimit()))
+
+        def _dfs(v):
+            nonlocal now_ord, group_num, visited, low, ids, ord_
+            low[v], ord_[v] = now_ord, now_ord
+            now_ord += 1
+            visited.append(v)
+            for i in range(g.start[v], g.start[v+1]):
+                to = g.elist[i]
+                if ord_[to] == -1:
+                    _dfs(to)
+                    low[v] = min(low[v], low[to])
+                else:
+                    low[v] = min(low[v], ord_[to])
+            if low[v] == ord_[v]:
+                while True:
+                    u = visited[-1]
+                    visited.pop()
+                    ord_[u] = self._n
+                    ids[u] = group_num
+                    if u == v:
+                        break
+                group_num += 1
+
+        for i in range(self._n):
+            if ord_[i] == -1:
+                _dfs(i)
+        ids = [group_num - 1 - x for x in ids]
+        return [group_num, ids]
+
+    def scc(self):
+        group_num, ids = self.scc_ids()
+        counts = [0] * group_num
+        groups = [[] for _ in range(group_num)]
+        for x in ids:
+            counts[x] += 1
+        for i in range(self._n):
+            groups[ids[i]].append(i)
+        return groups

--- a/atcoder/internal_scc.py
+++ b/atcoder/internal_scc.py
@@ -1,0 +1,10 @@
+class InternalScc():
+    def __init__(self, n=0):
+        self._n = n
+        self.edges = [] # [int, edge]
+        
+    def num_vertices(self):
+        return self._n
+    
+    def add_edge(self, from_, to):
+        self.edges.append([from_, [to]])

--- a/atcoder/scc.py
+++ b/atcoder/scc.py
@@ -1,0 +1,16 @@
+from atcoder import InternalScc
+
+
+class Scc(InternalScc):
+    """
+    有向グラフの強連結成分分解
+    https://atcoder.github.io/ac-library/document_ja/scc.html
+
+    InternalSccを継承
+    """
+
+    def add_edge(self, from_, to):
+        n = super().num_vertices()
+        assert 0 <= from_ < n
+        assert 0 <= to < n
+        super().add_edge(from_, to)

--- a/tests/test_internal_scc.py
+++ b/tests/test_internal_scc.py
@@ -1,0 +1,17 @@
+from atcoder import InternalScc
+import pytest
+
+def test_empty():
+    graph0 = InternalScc()
+    graph1 = InternalScc(0)
+    assert len([]) == len(graph0.edges)
+    assert len([]) == len(graph1.edges)
+
+def test_assign():
+    pass
+
+def test_selfloop():
+    pass
+
+def test_invalid():
+    pass

--- a/tests/test_internal_scc.py
+++ b/tests/test_internal_scc.py
@@ -1,17 +1,31 @@
 from atcoder import InternalScc
 import pytest
 
+
 def test_empty():
     graph0 = InternalScc()
     graph1 = InternalScc(0)
-    assert len([]) == len(graph0.edges)
-    assert len([]) == len(graph1.edges)
+    assert [] == graph0.scc()
+    assert [] == graph1.scc()
+
 
 def test_assign():
-    pass
+    graph = InternalScc(10)
+    assert isinstance(graph, InternalScc)
+
+
+def test_simple():
+    graph = InternalScc(2)
+    graph.add_edge(0, 1)
+    graph.add_edge(1, 0)
+    scc = graph.scc()
+    assert len(scc) == 1
+
 
 def test_selfloop():
-    pass
-
-def test_invalid():
-    pass
+    graph = InternalScc(2)
+    graph.add_edge(0, 0)
+    graph.add_edge(0, 0)
+    graph.add_edge(1, 1)
+    scc = graph.scc()
+    assert len(scc) == 2

--- a/tests/test_scc.py
+++ b/tests/test_scc.py
@@ -1,21 +1,21 @@
-from atcoder import InternalScc
+from atcoder import Scc
 import pytest
 
 
 def test_empty():
-    graph0 = InternalScc()
-    graph1 = InternalScc(0)
+    graph0 = Scc()
+    graph1 = Scc(0)
     assert [] == graph0.scc()
     assert [] == graph1.scc()
 
 
 def test_assign():
-    graph = InternalScc(10)
-    assert isinstance(graph, InternalScc)
+    graph = Scc(10)
+    assert isinstance(graph, Scc)
 
 
 def test_simple():
-    graph = InternalScc(2)
+    graph = Scc(2)
     graph.add_edge(0, 1)
     graph.add_edge(1, 0)
     scc = graph.scc()
@@ -23,9 +23,15 @@ def test_simple():
 
 
 def test_selfloop():
-    graph = InternalScc(2)
+    graph = Scc(2)
     graph.add_edge(0, 0)
     graph.add_edge(0, 0)
     graph.add_edge(1, 1)
     scc = graph.scc()
     assert len(scc) == 2
+
+
+def test_invalid():
+    graph = Scc(2)
+    with pytest.raises(AssertionError) as e:
+        graph.add_edge(0, 10)


### PR DESCRIPTION
- [x] [元ソース](https://github.com/atcoder/ac-library/blob/master/atcoder/internal_scc.hpp)の理解

  - [x] モックの作成(atcoder配下、test配下共に)
  - [x] 挙動についてコメントアウトとして記述

- [x] テストコードの完成
  - [x] scc()
  - [x] add_edge()
  - [テストコード参考](https://rinatz.github.io/python-book/ch08-02-pytest/)

- [x] コード実装
  - [x] scc()
  - [x] add_edge()